### PR TITLE
Add support for Body Content in Request (POST, PUT, ...)

### DIFF
--- a/DataCollector/GuzzleDataCollector.php
+++ b/DataCollector/GuzzleDataCollector.php
@@ -8,6 +8,7 @@ use Guzzle\Http\Message\Response as GuzzleResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\DataCollector\DataCollector;
+use Guzzle\Http\Message\EntityEnclosingRequestInterface;
 
 /**
  * GuzzleDataCollector.
@@ -41,6 +42,9 @@ class GuzzleDataCollector extends DataCollector
             $response = $request->getResponse();
 
             $requestContent = null;
+            if ($request instanceof EntityEnclosingRequestInterface) {
+                $requestContent = $request->getBody();
+            }
             $responseContent = $response->getBody(true);
 
             $time = array(
@@ -135,7 +139,7 @@ class GuzzleDataCollector extends DataCollector
      *
      * @return array
      */
-    private function sanitizeResponse(GuzzleResponse $response)
+    private function sanitizeResponse($response)
     {
         return array(
             'statusCode'   => $response->getStatusCode(),

--- a/Resources/views/Profiler/request.html.twig
+++ b/Resources/views/Profiler/request.html.twig
@@ -77,4 +77,9 @@
         {% endfor %}
         </tbody>
     </table>
+    
+    {% if requestContent is not empty %}
+        <h5>Content</h5>
+        <pre class="prettyprint linenums"><code class="language-javascript  ">{{ requestContent|replace({"\t\t\n": "", "\t": "  "}) }}</code></pre>
+    {% endif %}
 </div>


### PR DESCRIPTION
Hi,

I've just added support for body content in Request UI. Indeed, all EntityEnclosingRequest can be better "debugged" with their body content.

Thanks for this Bundle ! It has really made my day :) 
