### PR TITLE
we need to store string instead of object for request

### DIFF
--- a/DataCollector/GuzzleDataCollector.php
+++ b/DataCollector/GuzzleDataCollector.php
@@ -43,7 +43,7 @@ class GuzzleDataCollector extends DataCollector
 
             $requestContent = null;
             if ($request instanceof EntityEnclosingRequestInterface) {
-                $requestContent = $request->getBody();
+                $requestContent = (string) $request->getBody();
             }
             $responseContent = $response->getBody(true);
 


### PR DESCRIPTION
EntityBody contain a stream object which is not available inside the profiler
