### PR TITLE
Fixed a bug when having array-like parameters in the query string.

### DIFF
--- a/Resources/views/Profiler/request.html.twig
+++ b/Resources/views/Profiler/request.html.twig
@@ -1,3 +1,16 @@
+{% macro display_array_recursive(array, separator = ', ', opening_char = '[', closing_char = ']') -%}
+{{ opening_char }}
+{%- for key, value in array -%}
+    {%- if value is iterable -%}
+        {{ key }} => {{ _self.display_array_recursive(value, separator, opening_char, closing_char) }}
+    {%- else -%}
+        {{ key }} => {{ value }}
+        {%- if not loop.last %}{{ separator }}{% endif -%}
+    {%- endif -%}
+{%- endfor -%}
+{{ closing_char }}
+{%- endmacro %}
+
 <div id="request_{{ index }}" class="tab-pane active">
     {% set connection_percent = (100 * time.connection) / time.total %}
     {% set process_percent = (100 * (time.total - time.connection)) / time.total %}
@@ -72,12 +85,18 @@
         {% for name,parameter in request.query_parameters %}
             <tr>
                 <th>{{ name }}</th>
-                <td>{{ parameter }}</td>
+                <td>
+                    {% if parameter is iterable %}
+                        {{ _self.display_array_recursive(parameter) }}
+                    {% else %}
+                        {{ parameter }}
+                    {% endif %}
+                </td>
             </tr>
         {% endfor %}
         </tbody>
     </table>
-    
+
     {% if requestContent is not empty %}
         <h5>Content</h5>
         <pre class="prettyprint linenums"><code class="language-javascript  ">{{ requestContent|replace({"\t\t\n": "", "\t": "  "}) }}</code></pre>


### PR DESCRIPTION
Hey there,

This PR is about fixing a bug when having array-like parameters in the query string of a guzzle call. Before this patch, the profiler could not be shown because it throws an exception:

```
An exception has been thrown during the rendering of a template ("Notice: Array to string conversion in /home/pierreyves/projects/symfony2/xxxxxxx/app/cache/dev/twig/8e/0d/8b3b4f55ad9365b3a14408ef3e15.php line 164") in PlaybloomGuzzleBundle:Collector:guzzle.html.twig at line 46.
```

The parameters are now shown like the following examples:

```
?foo=bar             --> bar
?foo[]=bar&foo[]=baz --> [0 => bar, 1 => baz]
?foo[bar][baz]=hey   --> [bar => [baz => hey]]
```

Regards.
