### PR TITLE
Total execution time.

### DIFF
--- a/Resources/views/Collector/guzzle.html.twig
+++ b/Resources/views/Collector/guzzle.html.twig
@@ -24,7 +24,11 @@
         </div>
         <div class="sf-toolbar-info-piece">
             <b>Requests time</b>
-            {{ (collector.totalTime*1000)|number_format(0, '', '') }} ms
+            {% if collector.totalTime > 1.0 %}
+                <span>{{ '%0.2f'|format(collector.totalTime) }} s</span>
+            {% else %}
+                <span>{{ '%0.0f'|format(collector.totalTime * 1000) }} ms</span>
+            {% endif %}
         </div>
     {% endset %}
 


### PR DESCRIPTION
Hi,

This PR is about adding the total execution time in the profiler menu, like doctrine does it.
I also fixed the debug bar tooltip to use the same formatting as the profiler menu: when the total time exceed 1s, the result is displayed in seconds. Otherwise, the result is displayed in milliseconds.

![guzzle](https://f.cloud.github.com/assets/351471/567028/221b099e-c6a7-11e2-803b-ce2b5bb4bd05.png)
