### PR TITLE
Support for Symfony 2.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     ],
     "require": {
         "php": ">=5.3.0",
-        "symfony/web-profiler-bundle": "~2.1.0",
+        "symfony/web-profiler-bundle": "~2.1",
         "guzzle/guzzle": "3.*"
     },
     "autoload": {


### PR DESCRIPTION
Hi,

since Symfony 2.3 has just landed, it is now required to update the composer.json to support it. I've changed it to support 2.1+ (~2.1.0) versions. Can you update it and tag a 1.0.0 version so that I can keep my minimum-stability to "stable" ?
Thanks
