### PR TITLE
add a test to avoid a division by zero

### DIFF
--- a/Resources/views/Profiler/request.html.twig
+++ b/Resources/views/Profiler/request.html.twig
@@ -12,34 +12,36 @@
 {%- endmacro %}
 
 <div id="request_{{ index }}" class="tab-pane active">
-    {% set connection_percent = (100 * time.connection) / time.total %}
-    {% set process_percent = (100 * (time.total - time.connection)) / time.total %}
+    {% if time.total > 0 %}
+      {% set connection_percent = (100 * time.connection) / time.total %}
+      {% set process_percent = (100 * (time.total - time.connection)) / time.total %}
 
-    <h5>Time</h5>
-    <table>
-        <tbody>
-            <tr>
-                <th>Duration total</th>
-                <td>{{ (time.total * 1000)|number_format(0, '', '') }} <small>ms</small></td>
-            </tr>
-            <tr>
-                <th>Duration connection</th>
-                <td>{{ (time.connection * 1000)|number_format(0, '', '') }} <small>ms</small> - {{ connection_percent|number_format(0, '', '') }}%</td>
-            </tr>
-            <tr>
-                <th>Duration process</th>
-                <td>{{ ((time.total - time.connection) * 1000)|number_format(0, '', '') }} <small>ms</small> - {{ process_percent|number_format(0, '', '') }}%</td>
-            </tr>
-            <tr>
-                <td colspan="2">
-                    <div class="progress progress-striped">
-                        <div class="bar bar-warning" style="width: {{ connection_percent|number_format(0) }}%;">wait {{ connection_percent|number_format(0) }} %</div>
-                        <div class="bar bar-success" style="width: {{ process_percent|number_format(0) }}%;">process {{ process_percent|number_format(0) }} %</div>
-                    </div>
-                </td>
-            </tr>
-        </tbody>
-    </table>
+      <h5>Time</h5>
+      <table>
+          <tbody>
+              <tr>
+                  <th>Duration total</th>
+                  <td>{{ (time.total * 1000)|number_format(0, '', '') }} <small>ms</small></td>
+              </tr>
+              <tr>
+                  <th>Duration connection</th>
+                  <td>{{ (time.connection * 1000)|number_format(0, '', '') }} <small>ms</small> - {{ connection_percent|number_format(0, '', '') }}%</td>
+              </tr>
+              <tr>
+                  <th>Duration process</th>
+                  <td>{{ ((time.total - time.connection) * 1000)|number_format(0, '', '') }} <small>ms</small> - {{ process_percent|number_format(0, '', '') }}%</td>
+              </tr>
+              <tr>
+                  <td colspan="2">
+                      <div class="progress progress-striped">
+                          <div class="bar bar-warning" style="width: {{ connection_percent|number_format(0) }}%;">wait {{ connection_percent|number_format(0) }} %</div>
+                          <div class="bar bar-success" style="width: {{ process_percent|number_format(0) }}%;">process {{ process_percent|number_format(0) }} %</div>
+                      </div>
+                  </td>
+              </tr>
+          </tbody>
+      </table>
+    {% endif %}
 
     <h5>Informations</h5>
     <table>


### PR DESCRIPTION
When the cacheplugin is used in guzzle, the total time
of the request is zero.

So when calculating the percents in the debug bar there is
an exception :

```
An exception has been thrown during the rendering of a template
("Warning: Division by zero in FILE) in
PlaybloomGuzzleBundle:Profiler:request.html.twig at line 15
```

To avoid this we do not calculate to percents nor display to
time table (witch is irrelevant in this case).
