### PR TITLE
remove "<strong>" displayed in response headers

### DIFF
--- a/Resources/views/Profiler/response.html.twig
+++ b/Resources/views/Profiler/response.html.twig
@@ -19,7 +19,9 @@
         {% for header,value in response.headers %}
             <tr>
                 <th>{{ header }}</th>
-                <td>{{ value|join('<strong>, </strong>') }}</td>
+                <td>
+                    {{ value|join(', ') }}
+                </td>
             </tr>
         {% endfor %}
         </tbody>


### PR DESCRIPTION
When the response header has multiple values, the value is
 displayed like this in the profiler :

```
| set-cookie | value1 <strong>, </strong> value2
```

Now it's just displayed like this :

```
| set-cookie | value1, value2
```
