### PR TITLE
Don't ignore vendor directory in Resources

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 composer.lock
 composer.phar
-vendor/
+/vendor/
 
 # Test
 .atoum.php


### PR DESCRIPTION
Apparently the `Resources/public/vendor` directory is getting excluded when pulling in GuzzleBundle via Composer.

Specifically ignoring only the root vendor folder should fix this issue.
