### PR TITLE
Add a clickable URL for the request

### DIFF
--- a/Resources/views/Profiler/request.html.twig
+++ b/Resources/views/Profiler/request.html.twig
@@ -66,6 +66,12 @@
                 <th>Query</th>
                 <td>{{ request.query }}</td>
             </tr>
+            {% if request.method == 'GET' %}
+            <tr>
+                <th>URL</th>
+                <td><a href="{{ request.scheme }}://{{ request.host }}{{ request.path }}?{{ request.query }}">{{ request.scheme }}://{{ request.host }}{{ request.path }}?{{ request.query }}</a></td>
+            </tr>
+            {% endif %}
         </tbody>
     </table>
 


### PR DESCRIPTION
I often find myself copypasting the host, path and query into a new tab to replicate the Guzzle call. This link would allow me to do this in one click.